### PR TITLE
Use the new Web API Interface

### DIFF
--- a/intermediate.js
+++ b/intermediate.js
@@ -95,6 +95,7 @@ const transformHtmls = async (config) => {
   files.forEach((file, index) => {
     urls[file] = `require('${jsFiles[index]}')`
   })
+  urls['_catch_all.html'] = urls['_catch_all.html'] || urls['index.html']
   const htmlsFile = path.join(config.serverDestDir, '_htmls.js')
   const code = generateCode(urls)
   fse.writeFile(htmlsFile, code)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "fab-static": "bin.js"
   },
+  "scripts": {
+    "test-server": "supervisor test.js"
+  },
   "repository": "git@github.com:bitgenics/fab-static.git",
   "author": "Erwin van der Koogh <hello@bitgenics.io>",
   "license": "MIT",
@@ -16,5 +19,9 @@
     "globby": "^8.0.1",
     "mime-types": "^2.1.19",
     "webpack": "^4.17.1"
+  },
+  "devDependencies": {
+    "node-fetch": "^2.2.1",
+    "supervisor": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgenics/fab-static",
-  "version": "0.5.0-rc2",
+  "version": "0.5.0-rc3",
   "description": "Front-end Application Bundle generator for (mostly) static applications.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgenics/fab-static",
-  "version": "0.4.1",
+  "version": "0.5.0-rc2",
   "description": "Front-end Application Bundle generator for (mostly) static applications.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgenics/fab-static",
-  "version": "0.5.0-rc3",
+  "version": "0.5.0",
   "description": "Front-end Application Bundle generator for (mostly) static applications.",
   "main": "index.js",
   "bin": {

--- a/server.js
+++ b/server.js
@@ -53,11 +53,6 @@ const getHtmlHeaders = async (req, settings) => {
   return headers
 }
 
-const getContentType = (pathname) => {
-  const mimeType = mime.lookup(pathname)
-  return mimeType ? mime.contentType(mimeType) : 'text/html; charset=utf-8'
-}
-
 const handleRedirectToAssets = async (req, _, next) => {
   if (config.redirectToAssets && req.pathname.startsWith(STATIC_DIR_PATH)) {
     console.log('redirecting!')

--- a/server.js
+++ b/server.js
@@ -152,24 +152,6 @@ const handler = getRequestHandler([
   handle404,
 ])
 
-const renderGet = async (req, res, settings) => {
-  try {
-    console.log(getPath(req.url))
-    const headers = await getHeaders(req, settings)
-    for (header of headers) {
-      res.setHeader(header.name, header.value)
-    }
-    handler(req, res, settings)
-  } catch (e) {
-    if (!res.headersSent) {
-      res.statusCode = 500
-    }
-    console.log(e)
-  } finally {
-    res.end()
-  }
-}
-
 const render = async (req, settings) => {
   console.log({ req, settings })
   try {
@@ -184,4 +166,4 @@ const render = async (req, settings) => {
   }
 }
 
-module.exports = { renderGet, render }
+module.exports = { render }

--- a/server.js
+++ b/server.js
@@ -99,7 +99,7 @@ const handleHTML = async (req, settings, next) => {
   const html_handler = htmls[pathname]
     ? htmls[pathname]
     : accepts_html
-    ? htmls['/200.html']
+    ? htmls['/_catch_all.html']
     : null
 
   if (html_handler) {

--- a/server.js
+++ b/server.js
@@ -111,6 +111,7 @@ const handleHTML = async (req, settings, next) => {
 
   if (html_handler) {
     const headers = await getHtmlHeaders(req, settings)
+    headers.set('Content-Type', 'text/html; charset=utf-8')
     const data = {
       settings: JSON.stringify(settings),
       nonce: 'abcde12345',

--- a/server.js
+++ b/server.js
@@ -116,12 +116,12 @@ const handleHTML = async (req, settings, next) => {
     })
     return response
   } else {
-    next()
+    return next()
   }
 }
 
-const handle404 = async (_, res) => {
-  return new Response(content, {
+const handle404 = async () => {
+  return new Response('Content not Found', {
     status: 404,
   })
 }

--- a/server.js
+++ b/server.js
@@ -42,15 +42,12 @@ const getPath = (url) => {
 }
 
 const getHtmlHeaders = async (req, settings) => {
-  let headers = config.getHtmlHeaders
-    ? config.getHtmlHeaders(req, settings)
-    : []
-  console.log({ headers })
-  headers = headers || []
+  let headers = config.getHtmlHeaders && config.getHtmlHeaders(req, settings)
   if (headers && typeof headers.then == 'function') {
     headers = await headers
   }
-  return headers
+  headers = headers || {}
+  return headers instanceof Headers ? headers : new Headers(headers)
 }
 
 const handleRedirectToAssets = async (req, _, next) => {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,3 @@
-const url_parse = require('url').parse
-const mime = require('mime-types')
-
 const HOUR_IN_SEC = 60 * 60
 
 const default_config = {
@@ -37,7 +34,7 @@ console.log({ files })
 console.log({ htmls })
 
 const getPath = (url) => {
-  let pathname = url_parse(url).pathname
+  let pathname = new URL(url).pathname
   if (pathname.endsWith('/')) {
     pathname += 'index.html'
   }
@@ -81,15 +78,11 @@ const handleRedirectToAssets = async (req, _, next) => {
 const handleFiles = async (req, _, next) => {
   if (files[req.pathname]) {
     const content = files[req.pathname]
-    //const charset = content instanceof String ? 'utf-8' : undefined
-    const headers = {
-      'Cache-Control': `public, max-age=${config.cacheStatic}`,
-      'Content-Type': getContentType(req.pathname),
-    }
+
     console.log({ content })
-    const response = new Response(content, {
+    const response = new Response(content.bytes, {
       status: 200,
-      headers,
+      headers: content.headers,
     })
     console.log({ response })
     return response

--- a/template.js
+++ b/template.js
@@ -3,7 +3,7 @@ const StringToBuffer = (str) => {
 }
 
 const writeText = (fragment, index) => {
-  if(fragment.type === 'text' && fragment.contents.length > 0) {
+  if (fragment.type === 'text' && fragment.contents.length > 0) {
     let text = fragment.contents.replace(/(\\{\\{)/g, '{{')
     text = text.replace(/(\\}\\})/g, '}}')
     return `text[${index}] = Buffer.from('${StringToBuffer(text)}', 'base64')`
@@ -17,9 +17,9 @@ const template = (content) => {
   const regex = /(.*?){{\s*(\S*?)\s*}}([^\\{]*)/gm
   let lastIndex = 0
   while ((results = regex.exec(content)) !== null) {
-    fragments.push({type: 'text', contents: results[1]})
-    fragments.push({type: 'parameter', contents: results[2]})
-    fragments.push({type: 'text', contents: results[3]})
+    fragments.push({ type: 'text', contents: results[1] })
+    fragments.push({ type: 'parameter', contents: results[2] })
+    fragments.push({ type: 'text', contents: results[3] })
     lastIndex = regex.lastIndex
   }
   const rest = content.substring(lastIndex)
@@ -41,8 +41,20 @@ const renderToStream = (out, data) => {
   })
 }
 
-module.exports = { renderToStream }`
-  
+const renderToBuffer = (data) => {
+  const arr = []
+  text.forEach((item) => {
+    if(typeof item === 'string') {
+      arr.push(Buffer.from(data[item]))
+    } else {
+      arr.push(item)
+    }
+  })
+  return Buffer.concat(arr)
+}
+
+module.exports = { renderToStream, renderToBuffer }`
+
   return code
 }
 

--- a/test.js
+++ b/test.js
@@ -2,30 +2,61 @@ const fs = require('fs')
 const http = require('http')
 const url_parse = require('url').parse
 const mime = require('mime-types')
+const fetch = require('node-fetch')
 const path = require('path')
+
+global.fetch = fetch
+global.Request = fetch.Request
+global.Response = fetch.Response
+global.Headers = fetch.Headers
 
 const dir = path.resolve(process.argv[2] || './test/fab-dist')
 
 const fab = require(`${dir}/server/bundle.js`)
 
-const getContentType = pathname => {
+const getContentType = (pathname) => {
   const mimeType = mime.lookup(pathname)
   return mimeType ? mime.contentType(mimeType) : 'text/html; charset=utf-8'
 }
 
-http.createServer(async (req, res) => {
-	const pathname = url_parse(req.url).pathname
-	if(pathname.startsWith('/_assets')) {
-		fs.readFile(`${dir}${pathname}`, (err, data) => {
-			res.setHeader('Content-Type', getContentType(pathname))
-			res.end(data)
-		})
-	} else {
-		await fab.renderGet(req, res, {
-			injected: 'variables',
-			should: 'work!'
-		})
-	}
-}).listen(3005)
+const mapToObj = (map) => {
+  return [...map.entries()].reduce(
+    (obj, [key, value]) => ((obj[key] = value), obj),
+    {}
+  )
+}
+
+http
+  .createServer(async (req, res) => {
+    const pathname = url_parse(req.url).pathname
+    if (pathname.startsWith('/_assets')) {
+      fs.readFile(`${dir}${pathname}`, (err, data) => {
+        res.setHeader('Content-Type', getContentType(pathname))
+        res.end(data)
+      })
+    } else {
+      const { method, headers } = req
+      const url = `https://${req.headers.host}${req.url}`
+      const fetch_req = new Request(url, {
+        method,
+        headers,
+      })
+      const fetch_res = await fab.render(fetch_req, {
+        injected: 'variables',
+        should: 'work!',
+      })
+      console.log({ fetch_res })
+      res.writeHead(
+        fetch_res.status,
+        fetch_res.statusText,
+        mapToObj(fetch_res.headers)
+      )
+      const body = fetch_res.body
+      const blob = await fetch_res.arrayBuffer()
+      res.write(new Buffer(blob))
+      res.end()
+    }
+  })
+  .listen(3005)
 
 console.log('ready')

--- a/test.js
+++ b/test.js
@@ -51,7 +51,6 @@ http
         fetch_res.statusText,
         mapToObj(fetch_res.headers)
       )
-      const body = fetch_res.body
       const blob = await fetch_res.arrayBuffer()
       res.write(new Buffer(blob))
       res.end()

--- a/test/server/fab.config.js
+++ b/test/server/fab.config.js
@@ -1,26 +1,19 @@
+const html_headers = new Headers({
+  'Cache-Control': 'max-age=300',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'X-XSS-Protection': '1; mode=block',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31557600;includeSubdomains;preload',
+  'Content-Security-Policy':
+    "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; block-all-mixed-content;",
+  'Feature-Policy':
+    "autoplay: 'none'; camera 'none'; geolocation: 'none'; microphone 'none'; midi 'none'; payment 'none'",
+  'Expect-CT': 'enforce, max-age=30',
+})
+
 module.exports = {
-  getHeaders: async (req, settings) => {
-    return [
-      { name: 'Cache-Control', value: 'max-age=300' },
-      { name: 'X-Content-Type-Options', value: 'nosniff' },
-      { name: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-      { name: 'X-XSS-Protection', value: '1; mode=block' },
-      { name: 'X-Frame-Options', value: 'DENY' },
-      {
-        name: 'Strict-Transport-Security',
-        value: 'max-age=31557600;includeSubdomains;preload',
-      },
-      {
-        name: 'Content-Security-Policy',
-        value:
-          "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; block-all-mixed-content;",
-      },
-      {
-        name: 'Feature-Policy',
-        value:
-          "autoplay: 'none'; camera 'none'; geolocation: 'none'; microphone 'none'; midi 'none'; payment 'none'",
-      },
-      { name: 'Expect-CT', value: 'enforce, max-age=30' },
-    ]
+  getHtmlHeaders: async (req, settings) => {
+    return html_headers
   },
 }

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -7,7 +7,7 @@ const createConfig = (srcDir, targetDir) => {
     entry: {
       bundle: [path.resolve(srcDir, 'entry.js')],
     },
-    target: 'node',
+    target: 'webworker',
     resolve: {
       alias: {
         _includes: path.resolve(srcDir, '_includes.js'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,6 +1537,10 @@ neo-async@^2.5.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.2.tgz#489105ce7bc54e709d736b195f82135048c50fcc"
 
+node-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.1.tgz#1fe551e0ded6c45b3b3b937d0fb46f76df718d1e"
+
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -2134,6 +2138,11 @@ strip-ansi@^4.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+supervisor@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/supervisor/-/supervisor-0.12.0.tgz#de7e6337015b291851c10f3538c4a7f04917ecc1"
+  integrity sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=
 
 tapable@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hey @geelen, @plexey, this is a version of `fab-static` that bundles to a new fab interface, based on the Web APIs instead of NodeJS APIs. 
This should allow us to run Front-end Application Bundles in 156 datacentres world-wide with one API request to Cloudflare..

Can you update all sites except `linc-website` to use `fab-static > 0.5.0`? That way I can remove some backwards compatibility stuff in the renderers.